### PR TITLE
friction updates

### DIFF
--- a/input/paperExamples/5_hitCardHouse.txt
+++ b/input/paperExamples/5_hitCardHouse.txt
@@ -20,9 +20,9 @@ zoom 8
 
 view orthographic
 
-halfSpace 0 2.568 0  0 1 0  50 1.0
+halfSpace 0 2.568 0  0 1 0  50 0.9
 selfCollisionOn
-selfFric 1.0
+selfFric 0.9
 
 constraintSolver interiorPoint
 

--- a/input/paperExamples/videoExamples/armaRoller_stickSlip.txt
+++ b/input/paperExamples/videoExamples/armaRoller_stickSlip.txt
@@ -33,3 +33,5 @@ tuning 6
 1e-9
 1e-3
 1e-3
+
+fricIterAmt 2

--- a/input/paperExamples/videoExamples/hitLargeCardHouse.txt
+++ b/input/paperExamples/videoExamples/hitLargeCardHouse.txt
@@ -54,3 +54,5 @@ tuning 6
 
 tol 1
 2e-3
+
+fricIterAmt 2

--- a/src/TimeStepper/Optimizer.cpp
+++ b/src/TimeStepper/Optimizer.cpp
@@ -1511,6 +1511,10 @@ bool Optimizer<dim>::fullyImplicit_IP(void)
             for (int i = 0; i < MMLambda_lastH.back().size(); ++i) {
                 compute_g_b(constraintVal[startCI + i], dHat, MMLambda_lastH.back()[i]);
                 MMLambda_lastH.back()[i] *= -mu_IP * 2.0 * std::sqrt(constraintVal[startCI + i]);
+                if (MMActiveSet.back()[i][3] < -1) {
+                    // PP or PE duplication
+                    MMLambda_lastH.back()[i] *= -MMActiveSet.back()[i][3];
+                }
             }
 
             SelfCollisionHandler<dim>::computeDistCoordAndTanBasis(
@@ -1570,6 +1574,10 @@ bool Optimizer<dim>::fullyImplicit_IP(void)
                 for (int i = 0; i < MMLambda_lastH.back().size(); ++i) {
                     compute_g_b(constraintVal[startCI + i], dHat, MMLambda_lastH.back()[i]);
                     MMLambda_lastH.back()[i] *= -mu_IP * 2.0 * std::sqrt(constraintVal[startCI + i]);
+                    if (MMActiveSet.back()[i][3] < -1) {
+                        // PP or PE duplication
+                        MMLambda_lastH.back()[i] *= -MMActiveSet.back()[i][3];
+                    }
                 }
 
                 SelfCollisionHandler<dim>::computeDistCoordAndTanBasis(


### PR DESCRIPTION
Handled PP and PE duplication in friction computation (a bug in SIGGRAPH version). 
- This changes friction behavior a little bit but not any conclusions in the paper, some friction scripts are adjusted to maintain similar behavior.

Added step size reduction for efficient spatial hash in CCD

